### PR TITLE
Fix: Login failed with MyUpwayService

### DIFF
--- a/src/pyupway/services/myupwayservice.py
+++ b/src/pyupway/services/myupwayservice.py
@@ -55,6 +55,8 @@ class MyUpwayService:
         if not '.ASPXAUTH' in self._session.cookies:
             raise LoginErr("Login failed.")
 
+        self.get_current_values() # perform request to set the isOnline flag
+
     def get_current_values(self, variables: List[Variable] | None = None, force_login: bool = False) -> List[VariableValue]:
         """
         Returns current values for requested variables provided as list of VariableValue.


### PR DESCRIPTION
Login failed, because the isOnline flag had not yet been set. With this fix, login calls get_current_values without parameters to set the flag.