### PR TITLE
Retrieve and provide device id

### DIFF
--- a/src/pyupway/__init__.py
+++ b/src/pyupway/__init__.py
@@ -11,6 +11,7 @@ from .services import MyUpwayService, MyUplinkService
 class MyUpway:
     _config: MyUpwayConfig
 
+    deviceId: str
     isOnline: bool
 
     def __init__(self, config: MyUpwayConfig) -> None:
@@ -23,6 +24,7 @@ class MyUpway:
 
         self._service.login()
 
+        self.deviceId = self._service.deviceId
         self.isOnline = self._service.isOnline
 
     def login(self):

--- a/src/pyupway/services/myuplinkservice.py
+++ b/src/pyupway/services/myuplinkservice.py
@@ -16,8 +16,8 @@ class MyUplinkService:
     _config: MyUpwayConfig
     _session: requests.Session
     _token: str
-    _device_id: str
 
+    deviceId: str
     isOnline: bool
 
     def __init__(self, config: MyUpwayConfig) -> None:
@@ -34,7 +34,7 @@ class MyUplinkService:
 
         device_data = response_data['systems'][0]['devices'][0]
 
-        self._device_id = device_data['id']
+        self.deviceId = device_data['id']
         self.isOnline = device_data['connectionState'] == "Connected"
 
     def get_current_values(self, variables: List[Variable] | None = None, force_login: bool = False) -> List[VariableValue]:
@@ -50,12 +50,12 @@ class MyUplinkService:
                 "parameters": ','.join(str(variable.value) for variable in variables)
             }
         
-        response = self._session.get(self._BASE_URL + '/v2/devices/' + self._device_id + '/points', params=params)
+        response = self._session.get(self._BASE_URL + '/v2/devices/' + self.deviceId + '/points', params=params)
 
         if response.status_code == 401:
             self._get_token()
 
-            response = self._session.get(self._BASE_URL + '/v2/devices/' + self._device_id + '/points', params=params)
+            response = self._session.get(self._BASE_URL + '/v2/devices/' + self.deviceId + '/points', params=params)
 
         elif response.status_code != 200:
             raise Exception(f"Failed to get values. API responded with status code {response.status_code}")

--- a/src/pyupway/services/myupwayservice.py
+++ b/src/pyupway/services/myupwayservice.py
@@ -29,6 +29,7 @@ class MyUpwayService:
     _config: MyUpwayConfig
     _session: requests.Session
 
+    deviceId: str
     isOnline: bool
 
     def __init__(self, config: MyUpwayConfig) -> None:
@@ -36,6 +37,8 @@ class MyUpwayService:
         self._session = requests.Session()
         # Set language to en to be able to get boolean values right
         self._session.cookies.set("EmilLanguage", "en-GB", domain=self._DOMAIN)
+
+        self.deviceId = self._config.heatpump_id
 
         self.login()
 


### PR DESCRIPTION
The MyUplinkService retrieves the device id from the API, whereas the MyUpwayService just forwards the value passed to it in the configuration.

In both cases, the device id can be accessed in the deviceId variable of the MyUpway object.